### PR TITLE
Add test for making sure `addQueryArgs` updates existing arguments.

### DIFF
--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -17,4 +17,11 @@ describe( 'addQueryArgs', () => {
 
 		expect( addQueryArgs( url, args ) ).toBe( 'https://andalouses.com/beach?night=false&sun=true&sand=false' );
 	} );
+
+	test( 'should update args to an URL with conflicting query string', () => {
+		const url = 'https://andalouses.com/beach?night=false&sun=false&sand=true';
+		const args = { sun: 'true', sand: 'false' };
+
+		expect( addQueryArgs( url, args ) ).toBe( 'https://andalouses.com/beach?night=false&sun=true&sand=false' );
+	} );
 } );


### PR DESCRIPTION
This is to ensure it will not leave duplicate arguments behind.